### PR TITLE
Fix Smithing Recipes and update to 1.19.3

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -6,16 +6,16 @@ org.gradle.warning.mode = all
 ##########################################################################
 # Standard Fabric Dependencies
 # Check these on https://fabricmc.net/develop/
-minecraft_version = 1.19.2
-yarn_mappings = 1.19.2+build.28
+minecraft_version = 1.19.3
+yarn_mappings = 1.19.3+build.5
 loader_version = 0.14.10
 # Fabric API
-fabric_version = 0.66.0+1.19.2
+fabric_version = 0.72.0+1.19.3
 loom_version = 1.0-SNAPSHOT
 java_version = 17
 ##########################################################################
 # Mod Properties
-mod_version = 1.2.0
+mod_version = 1.3.0
 maven_group = net.bloople
 archives_base_name = recipe-images-exporter
 ##########################################################################

--- a/src/main/java/net/bloople/recipeimagesexporter/mixins/SmithingRecipeAccessor.java
+++ b/src/main/java/net/bloople/recipeimagesexporter/mixins/SmithingRecipeAccessor.java
@@ -1,0 +1,15 @@
+package net.bloople.recipeimagesexporter.mixins;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+import net.minecraft.recipe.Ingredient;
+import net.minecraft.recipe.SmithingRecipe;
+
+@Mixin(SmithingRecipe.class)
+public interface SmithingRecipeAccessor {
+    @Accessor("base")
+    Ingredient getBase();
+    @Accessor("addition")
+    Ingredient getAddition();
+}

--- a/src/main/kotlin/net/bloople/recipeimagesexporter/BlastingRecipeImageGenerator.kt
+++ b/src/main/kotlin/net/bloople/recipeimagesexporter/BlastingRecipeImageGenerator.kt
@@ -2,7 +2,7 @@ package net.bloople.recipeimagesexporter
 
 import net.minecraft.item.ItemStack
 import net.minecraft.util.Identifier
-import net.minecraft.util.registry.Registry
+import net.minecraft.registry.Registries
 import java.awt.image.BufferedImage
 import java.lang.Integer.max
 import javax.imageio.ImageIO
@@ -22,7 +22,7 @@ class BlastingRecipeImageGenerator(
 
             createGraphics().use {
                 drawImage(itemsData.slotImage(recipeInfo.slot), 11, 11, null)
-                val coalStack = ItemStack(Registry.ITEM.get(Identifier("coal")), 1)
+                val coalStack = ItemStack(Registries.ITEM.get(Identifier("coal")), 1)
                 drawImage(itemsData.slotImage(coalStack), 11, 83, null)
                 drawImage(itemsData.outputImage(recipeInfo.output), 130, 46, null)
 

--- a/src/main/kotlin/net/bloople/recipeimagesexporter/RecipeConverters.kt
+++ b/src/main/kotlin/net/bloople/recipeimagesexporter/RecipeConverters.kt
@@ -144,8 +144,14 @@ fun convertStonecuttingRecipe(recipe: StonecuttingRecipe): List<StonecuttingReci
 fun convertSmithingRecipe(recipe: SmithingRecipe): List<SmithingRecipeInfo> {
     val recipePath = "smithing/${recipe.id.namespace}/${recipe.id.path}"
 
-    val base = recipe.javaClass.getDeclaredField("base").get(recipe) as Ingredient
-    val addition = recipe.javaClass.getDeclaredField("addition").get(recipe) as Ingredient
+    val baseField = recipe.javaClass.getDeclaredField("field_25389") // base
+    val additionField = recipe.javaClass.getDeclaredField("field_25390") // addition
+
+    baseField.trySetAccessible()
+    additionField.trySetAccessible()
+
+    val base = baseField.get(recipe) as Ingredient // field_25389
+    val addition = additionField.get(recipe) as Ingredient // field_25390
 
     val maxStacksSize = arrayOf(base, addition).maxOf { it.matchingStacks.size }
 

--- a/src/main/kotlin/net/bloople/recipeimagesexporter/RecipeConverters.kt
+++ b/src/main/kotlin/net/bloople/recipeimagesexporter/RecipeConverters.kt
@@ -1,5 +1,6 @@
 package net.bloople.recipeimagesexporter
 
+import net.bloople.recipeimagesexporter.mixins.SmithingRecipeAccessor
 import net.minecraft.item.ItemStack
 import net.minecraft.recipe.*
 
@@ -144,14 +145,10 @@ fun convertStonecuttingRecipe(recipe: StonecuttingRecipe): List<StonecuttingReci
 fun convertSmithingRecipe(recipe: SmithingRecipe): List<SmithingRecipeInfo> {
     val recipePath = "smithing/${recipe.id.namespace}/${recipe.id.path}"
 
-    val baseField = recipe.javaClass.getDeclaredField("field_25389") // base
-    val additionField = recipe.javaClass.getDeclaredField("field_25390") // addition
+    val recipeAccessor = recipe as SmithingRecipeAccessor
 
-    baseField.trySetAccessible()
-    additionField.trySetAccessible()
-
-    val base = baseField.get(recipe) as Ingredient // field_25389
-    val addition = additionField.get(recipe) as Ingredient // field_25390
+    val base = recipeAccessor.getBase() as Ingredient
+    val addition = recipeAccessor.getAddition() as Ingredient
 
     val maxStacksSize = arrayOf(base, addition).maxOf { it.matchingStacks.size }
 

--- a/src/main/kotlin/net/bloople/recipeimagesexporter/Rendering.kt
+++ b/src/main/kotlin/net/bloople/recipeimagesexporter/Rendering.kt
@@ -11,7 +11,7 @@ import net.minecraft.client.texture.NativeImage
 import net.minecraft.client.util.ScreenshotRecorder
 import net.minecraft.client.util.math.MatrixStack
 import net.minecraft.text.Text
-import net.minecraft.util.math.Matrix4f
+import org.joml.Matrix4f
 
 
 fun renderToTexture(
@@ -42,11 +42,13 @@ fun renderToTexture(
         RenderSystem.viewport(0, 0, width, height)
 
         RenderSystem.clear(GlConst.GL_DEPTH_BUFFER_BIT, IS_SYSTEM_MAC)
-        val matrix4f = Matrix4f.projectionMatrix(
+        val matrix4f = Matrix4f()
+        // TODO: Fix rendering of items
+        matrix4f.ortho(
             0.0f,
             (width.toDouble() / scaleFactor).toFloat(),
-            0.0f,
             (height.toDouble() / scaleFactor).toFloat(),
+            0.0f,
             1000.0f,
             3000.0f
         )
@@ -58,7 +60,7 @@ fun renderToTexture(
         DiffuseLighting.enableGuiDepthLighting()
 
         RenderSystem.setShaderColor(1.0f, 1.0f, 1.0f, 1.0f)
-        RenderSystem.setShader { GameRenderer.getPositionTexShader() }
+        RenderSystem.setShader { GameRenderer.getPositionColorTexProgram() }
         RenderSystem.setShaderTexture(0, ClickableWidget.WIDGETS_TEXTURE)
 
         RenderSystem.enableBlend()

--- a/src/main/kotlin/net/bloople/recipeimagesexporter/SmeltingRecipeImageGenerator.kt
+++ b/src/main/kotlin/net/bloople/recipeimagesexporter/SmeltingRecipeImageGenerator.kt
@@ -2,7 +2,7 @@ package net.bloople.recipeimagesexporter
 
 import net.minecraft.item.ItemStack
 import net.minecraft.util.Identifier
-import net.minecraft.util.registry.Registry
+import net.minecraft.registry.Registries
 import java.awt.image.BufferedImage
 import java.lang.Integer.max
 import javax.imageio.ImageIO
@@ -22,7 +22,7 @@ class SmeltingRecipeImageGenerator(
 
             createGraphics().use {
                 drawImage(itemsData.slotImage(recipeInfo.slot), 11, 11, null)
-                val coalStack = ItemStack(Registry.ITEM.get(Identifier("coal")), 1)
+                val coalStack = ItemStack(Registries.ITEM.get(Identifier("coal")), 1)
                 drawImage(itemsData.slotImage(coalStack), 11, 83, null)
                 drawImage(itemsData.outputImage(recipeInfo.output), 130, 46, null)
 

--- a/src/main/kotlin/net/bloople/recipeimagesexporter/SmokingRecipeImageGenerator.kt
+++ b/src/main/kotlin/net/bloople/recipeimagesexporter/SmokingRecipeImageGenerator.kt
@@ -2,7 +2,7 @@ package net.bloople.recipeimagesexporter
 
 import net.minecraft.item.ItemStack
 import net.minecraft.util.Identifier
-import net.minecraft.util.registry.Registry
+import net.minecraft.registry.Registries
 import java.awt.image.BufferedImage
 import java.lang.Integer.max
 import javax.imageio.ImageIO
@@ -22,7 +22,7 @@ class SmokingRecipeImageGenerator(
 
             createGraphics().use {
                 drawImage(itemsData.slotImage(recipeInfo.slot), 11, 11, null)
-                val coalStack = ItemStack(Registry.ITEM.get(Identifier("coal")), 1)
+                val coalStack = ItemStack(Registries.ITEM.get(Identifier("coal")), 1)
                 drawImage(itemsData.slotImage(coalStack), 11, 83, null)
                 drawImage(itemsData.outputImage(recipeInfo.output), 130, 46, null)
 

--- a/src/main/kotlin/net/bloople/recipeimagesexporter/Util.kt
+++ b/src/main/kotlin/net/bloople/recipeimagesexporter/Util.kt
@@ -5,7 +5,7 @@ import net.minecraft.item.Item
 import net.minecraft.item.ItemStack
 import net.minecraft.text.Text
 import net.minecraft.util.Identifier
-import net.minecraft.util.registry.Registry
+import net.minecraft.registry.Registries
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import java.awt.AlphaComposite
@@ -29,7 +29,7 @@ fun <T> Array<out T>.getOrLast(index: Int): T? {
     return if (index in 0..lastIndex) get(index) else get(lastIndex)
 }
 
-val Item.identifier: Identifier get() = Registry.ITEM.getId(this)
+val Item.identifier: Identifier get() = Registries.ITEM.getId(this)
 
 val Identifier.itemResourceLocation: Identifier get() = Identifier(namespace, "textures/item/$path.png")
 

--- a/src/main/resources/recipeimagesexporter.mixins.json
+++ b/src/main/resources/recipeimagesexporter.mixins.json
@@ -5,5 +5,8 @@
   "injectors": {
     "defaultRequire": 1
   },
-  "mixins": []
+  "mixins": [],
+  "client": [
+    "SmithingRecipeAccessor"
+  ]
 }


### PR DESCRIPTION
I have updated the mod to 1.19.3. Also, because Fabric uses intermediary mappings when run outside of a development environment, I had to use a mixin accessor to get the correct field for SmithingRecipe.base and SmithingRecipe.addition.